### PR TITLE
feat: Added method castMediaMultiple for casting list of media with ability repeat all list or one file

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/ReadableMapUtils.java
+++ b/android/src/main/java/com/reactnative/googlecast/ReadableMapUtils.java
@@ -1,9 +1,10 @@
 package com.reactnative.googlecast;
 
 import android.graphics.Color;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 
 import java.util.Map;
@@ -23,6 +24,14 @@ public class ReadableMapUtils {
         }
 
         return map.getMap(key);
+    }
+
+    public static @Nullable ReadableArray getReadableArray(@NonNull ReadableMap map, @NonNull String key){
+        if(!map.hasKey(key)){
+            return null;
+        }
+
+        return map.getArray(key);
     }
 
     public static @Nullable Map<?, ?> getMap(@NonNull ReadableMap map, @NonNull String key) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,10 @@ declare module 'react-native-google-cast' {
     customData?: any
     textTrackStyle?: TextTrackStyle
   }
+  export type CastOptionsMultiple = {
+    castedMediaList: CastOptions[]
+    repeatMode?: number
+  }
 
   export type TextTrackStyle = {
     backgroundColor?: string
@@ -55,6 +59,7 @@ declare module 'react-native-google-cast' {
     getCastDevice(): Promise<CastDevice>
     getCastState(): Promise<CastState>
     castMedia(options: CastOptions): void
+    castMediaMultiple(options: CastOptionsMultiple): void
     endSession(stopCast?: boolean): Promise<boolean>
     play(): void
     pause(): void
@@ -69,7 +74,7 @@ declare module 'react-native-google-cast' {
     toggleSubtitles(enabled: boolean, languageCode?: string): Promise<void>
 
     EventEmitter: EventEmitter
-    
+
     SESSION_STARTING: string
     SESSION_STARTED: string
     SESSION_START_FAILED: string
@@ -78,12 +83,12 @@ declare module 'react-native-google-cast' {
     SESSION_RESUMED: string
     SESSION_ENDING: string
     SESSION_ENDED: string
-    
+
     MEDIA_STATUS_UPDATED: string
     MEDIA_PLAYBACK_STARTED: string
     MEDIA_PLAYBACK_ENDED: string
     MEDIA_PROGRESS_UPDATED: string
-    
+
     CHANNEL_CONNECTED: string
     CHANNEL_DISCONNECTED: string
     CHANNEL_MESSAGE_RECEIVED: string

--- a/index.js
+++ b/index.js
@@ -20,24 +20,24 @@ type CastDevice = {
 }
 
 type CastState =
-  | 'NoDevicesAvailable'
-  | 'NotConnected'
-  | 'Connecting'
-  | 'Connected'
+| 'NoDevicesAvailable'
+| 'NotConnected'
+| 'Connecting'
+| 'Connected'
 
 type TextTrackStyle = {
-  backgroundColor?: string,
-  edgeColor?: string,
-  edgeType?: 'depressed' | 'dropShadow' | 'none' | 'outline' | 'raised',
-  fontFamily?: string,
-  fontGenericFamily?:
-    | 'casual'
-    | 'cursive'
-    | 'monoSansSerif'
-    | 'monoSerif'
-    | 'sansSerif'
-    | 'serif'
-    | 'smallCaps',
+    backgroundColor?: string,
+    edgeColor?: string,
+    edgeType?: 'depressed' | 'dropShadow' | 'none' | 'outline' | 'raised',
+    fontFamily?: string,
+    fontGenericFamily?:
+  | 'casual'
+  | 'cursive'
+  | 'monoSansSerif'
+  | 'monoSerif'
+  | 'sansSerif'
+  | 'serif'
+  | 'smallCaps',
   fontScale?: number,
   fontStyle?: 'bold' | 'boldItalic' | 'italic' | 'normal',
   foregroundColor?: string,
@@ -55,7 +55,7 @@ export default {
       state =>
         ['NoDevicesAvailable', 'NotConnected', 'Connecting', 'Connected'][
           state
-        ],
+          ],
     )
   },
   castMedia(params: {
@@ -73,6 +73,34 @@ export default {
     textTrackStyle?: TextTrackStyle,
   }) {
     return GoogleCast.castMedia(params)
+  },
+  /**
+   *
+   * @param params {
+   *   replayMode: REPEAT_MODE_REPEAT_OFF = 0, REPEAT_MODE_REPEAT_ALL = 1, REPEAT_MODE_REPEAT_SINGLE = 2
+   *   castedMediaList: list of CastOptions
+   *   {
+    mediaUrl: string,
+    title?: string,
+    subtitle?: string,
+    studio?: string,
+    imageUrl?: string,
+    posterUrl?: string,
+    contentType?: string,
+    streamDuration?: number,
+    playPosition?: number,
+    isLive?: boolean,
+    customData?: Object,
+    textTrackStyle?: TextTrackStyle,
+  }
+   * }
+   *
+   */
+  castMediaMultiple(params: {
+    castedMediaList: any,
+    repeatMode?: number
+  }){
+    return GoogleCast.castMediaMultiple(params)
   },
   /**
    * Ends the current session.
@@ -129,16 +157,16 @@ export default {
    * @param {boolean} languageCode
    */
   toggleSubtitles(enabled: boolean, languageCode?: string) {
-    return GoogleCast.toggleSubtitles(enabled, languageCode)
-  },
+  return GoogleCast.toggleSubtitles(enabled, languageCode)
+},
 
-  // TODO use the same native event interface instead of hacking it here
-  EventEmitter:
-    Platform.OS === 'ios'
-      ? new NativeEventEmitter(GoogleCast)
-      : DeviceEventEmitter,
+// TODO use the same native event interface instead of hacking it here
+EventEmitter:
+  Platform.OS === 'ios'
+    ? new NativeEventEmitter(GoogleCast)
+    : DeviceEventEmitter,
 
-  SESSION_STARTING: GoogleCast.SESSION_STARTING,
+    SESSION_STARTING: GoogleCast.SESSION_STARTING,
   SESSION_STARTED: GoogleCast.SESSION_STARTED,
   SESSION_START_FAILED: GoogleCast.SESSION_START_FAILED,
   SESSION_SUSPENDED: GoogleCast.SESSION_SUSPENDED,


### PR DESCRIPTION
I had problems with looping the video, 
so I added a method for casting a queue from files with the ability to loop one or the whole queue.